### PR TITLE
Allow default port with 80

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,7 +17,7 @@ import (
 func main() {
 	log.Init()
 
-	port := util.MustGetEnvUInt32("PORT")
+	port := util.GetEnvOrDefaultUInt32("PORT", "80")
 	dbURL := util.MustGetEnv("DATABASE_URL")
 
 	initUserJWT()

--- a/util/util.go
+++ b/util/util.go
@@ -18,10 +18,27 @@ func MustGetEnv(env string) string {
 
 // MustGetEnvUInt32 gets the env and parses to uint32
 func MustGetEnvUInt32(env string) uint32 {
-	envValue := MustGetEnv(env)
+	return envParseUInt32(env, MustGetEnv(env))
+}
+
+// GetEnvOrDefault gets an environment variable or uses the default value
+func GetEnvOrDefault(env, defaultValue string) string {
+	envValue := os.Getenv(env)
+	if envValue == "" {
+		return defaultValue
+	}
+	return envValue
+}
+
+// GetEnvOrDefaultUInt32 gets an environment variable (or default) and parses to uint32
+func GetEnvOrDefaultUInt32(env, defaultValue string) uint32 {
+	return envParseUInt32(env, GetEnvOrDefault(env, defaultValue))
+}
+
+func envParseUInt32(env, envValue string) uint32 {
 	val, err := strconv.ParseUint(envValue, 10, 32)
 	if err != nil {
-		logrus.WithFields(logrus.Fields{"env": env, "value": envValue}).Fatal("MustGetEnvUInt32 did not find uint32 value")
+		logrus.WithFields(logrus.Fields{"env": env, "value": envValue}).Fatal("envParseUInt32 did not find uint32 value")
 	}
 	return uint32(val)
 }


### PR DESCRIPTION
Because the app will be running in a container, it's not always necessary
to provide a port (since the container will map the port).